### PR TITLE
Fix alias for handle_params

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ teach yourself which snippet mnemonics you would prefer to use.
 | LiveView: handle_cast | plvs,plv,plvhi,def,def handle_cast | [Reference](#liveview-handle_cast) |
 | LiveView: handle_event | plvs,plv,plvhe,def,def handle_event | [Reference](#liveview-handle_event) |
 | LiveView: handle_info | plvs,plv,plvhi,def,def handle_info | [Reference](#liveview-handle_info) |
-| LiveView: handle_params | plvs,plv,plvhe,def,def handle_params | [Reference](#liveview-handle_params) |
+| LiveView: handle_params | plvs,plv,plvhp,def,def handle_params | [Reference](#liveview-handle_params) |
 | LiveView: render implementation | plvs,plv,plvr,def render | [Reference](#liveview-render-implementation) |
 | LiveView: socket destructure | plvs,plv,plvsd,socket | [Reference](#liveview-socket-destructure) |
 | LiveView: terminate | plvs,plv,plvt,def terminate | [Reference](#liveview-terminate) |
@@ -369,7 +369,7 @@ end
 
 ### Prefixes
 
-<pre>plvs,plv,plvhe,def,def handle_params</pre>
+<pre>plvs,plv,plvhp,def,def handle_params</pre>
 
 ### Template
 <pre>

--- a/lib/snippets.ex
+++ b/lib/snippets.ex
@@ -165,7 +165,7 @@ defmodule App.Snippets do
   def generate("live_view_handle_params") do
     %Snippet{
       name: "LiveView: handle_params",
-      prefix: ["plvs", "plv", "plvhe", "def", "def handle_params"]
+      prefix: ["plvs", "plv", "plvhp", "def", "def handle_params"]
     }
   end
 


### PR DESCRIPTION
Alias for `handle_params` should be `plvhp` instead of `plvhe`.