### PR TITLE
fix: use package.json language scopes

### DIFF
--- a/lib/app.ex
+++ b/lib/app.ex
@@ -3,7 +3,7 @@ defmodule App do
     snippet_directory = Path.absname("lib/priv/snippets", File.cwd!())
     {:ok, paths} = File.ls(snippet_directory)
 
-    snippet_json =
+    snippets =
       paths
       |> Enum.map(fn path ->
         file = File.read!(Path.absname(path, snippet_directory))
@@ -16,8 +16,6 @@ defmodule App do
         snippet_data
         |> Map.put(:description, "prefixes: #{snippet_data.prefix |> Enum.join(",")}")
       end)
-      |> Map.new(fn %{name: name} = meta_data -> {name, Map.delete(meta_data, :name)} end)
-      |> Jason.encode!()
 
     doc_table =
       paths
@@ -115,7 +113,20 @@ defmodule App do
 
     File.write("./README.md", docs)
 
-    File.write!("./snippets.json", snippet_json)
+    elixir_snippet_json =
+      snippets
+      |> Enum.filter(&(&1.scope == "elixir"))
+      |> Map.new(fn %{name: name} = meta_data -> {name, Map.delete(meta_data, :name)} end)
+      |> Jason.encode!()
+
+    phoenix_heex_snippet_json =
+      snippets
+      |> Enum.filter(&(&1.scope == "phoenix-heex"))
+      |> Map.new(fn %{name: name} = meta_data -> {name, Map.delete(meta_data, :name)} end)
+      |> Jason.encode!()
+
+    File.write!("./elixir.code-snippets", elixir_snippet_json)
+    File.write!("./phoenix-heex.code-snippets", phoenix_heex_snippet_json)
 
     args
     |> parse_args()

--- a/lib/snippets.ex
+++ b/lib/snippets.ex
@@ -4,6 +4,7 @@ defmodule App.Snippets do
   def generate("ecto_changeset") do
     %Snippet{
       name: "Ecto: Schema changeset",
+      scope: "elixir",
       prefix: ["plvs", "es", "esc"]
     }
   end
@@ -11,6 +12,7 @@ defmodule App.Snippets do
   def generate("ecto_optional_attrs") do
     %Snippet{
       name: "Ecto: Schema changeset optional attrs",
+      scope: "elixir",
       prefix: ["plvs", "es", "esoa"]
     }
   end
@@ -18,6 +20,7 @@ defmodule App.Snippets do
   def generate("ecto_required_attrs") do
     %Snippet{
       name: "Ecto: Schema changeset required attrs",
+      scope: "elixir",
       prefix: ["plvs", "es", "escra"]
     }
   end
@@ -25,6 +28,7 @@ defmodule App.Snippets do
   def generate("eex_case") do
     %Snippet{
       name: "eex: case",
+      scope: "phoenix-heex",
       prefix: ["plvs", "eex", "eexcase", "<% case"]
     }
   end
@@ -32,6 +36,7 @@ defmodule App.Snippets do
   def generate("eex_comments") do
     %Snippet{
       name: "eex: Comment",
+      scope: "phoenix-heex",
       prefix: ["plvs", "eex", "eexc", "<%#"]
     }
   end
@@ -39,6 +44,7 @@ defmodule App.Snippets do
   def generate("eex_cond") do
     %Snippet{
       name: "eex: cond",
+      scope: "phoenix-heex",
       prefix: ["plvs", "eex", "eexcond", "<% cond"]
     }
   end
@@ -46,6 +52,7 @@ defmodule App.Snippets do
   def generate("eex_for") do
     %Snippet{
       name: "eex: for",
+      scope: "phoenix-heex",
       prefix: ["plvs", "eex", "eexfor", "<% for"]
     }
   end
@@ -53,6 +60,7 @@ defmodule App.Snippets do
   def generate("eex_if") do
     %Snippet{
       name: "eex: if",
+      scope: "phoenix-heex",
       prefix: ["plvs", "eex", "eexif", "<% if"]
     }
   end
@@ -60,6 +68,7 @@ defmodule App.Snippets do
   def generate("eex_inline_with_output") do
     %Snippet{
       name: "eex: inline with output",
+      scope: "phoenix-heex",
       prefix: ["plvs", "eex", "<%"]
     }
   end
@@ -67,6 +76,7 @@ defmodule App.Snippets do
   def generate("eex_replace_with_result") do
     %Snippet{
       name: "eex: Replace with result",
+      scope: "phoenix-heex",
       prefix: ["plvs", "eex", "<%="]
     }
   end
@@ -74,6 +84,7 @@ defmodule App.Snippets do
   def generate("eex_return_contents_inside") do
     %Snippet{
       name: "eex: Return contents",
+      scope: "phoenix-heex",
       prefix: ["plvs", "eex", "eexr", "<%%"]
     }
   end
@@ -81,6 +92,7 @@ defmodule App.Snippets do
   def generate("live_component_assign_helper") do
     %Snippet{
       name: "LiveView: Phoenix.LiveComponent assign helper",
+      scope: "elixir",
       prefix: ["plvs", "plc", "plca", "plcah"]
     }
   end
@@ -88,6 +100,7 @@ defmodule App.Snippets do
   def generate("live_component_call") do
     %Snippet{
       name: "LiveView: Phoenix.LiveComponent call",
+      scope: "phoenix-heex",
       prefix: ["plvs", "plc", "plcc"]
     }
   end
@@ -95,6 +108,7 @@ defmodule App.Snippets do
   def generate("live_component_handle_event") do
     %Snippet{
       name: "LiveView: Phoenix.LiveComponent handle_event",
+      scope: "elixir",
       prefix: ["plvs", "plc", "plche"]
     }
   end
@@ -102,6 +116,7 @@ defmodule App.Snippets do
   def generate("live_component_impl") do
     %Snippet{
       name: "LiveView: @impl Phoenix.LiveComponent",
+      scope: "elixir",
       prefix: ["plvs", "plv", "@impl"]
     }
   end
@@ -109,6 +124,7 @@ defmodule App.Snippets do
   def generate("live_component_mount") do
     %Snippet{
       name: "LiveView: Phoenix.LiveComponent mount",
+      scope: "elixir",
       prefix: ["plvs", "plc", "plcm"]
     }
   end
@@ -116,6 +132,7 @@ defmodule App.Snippets do
   def generate("live_component_preload") do
     %Snippet{
       name: "LiveView: Phoenix.LiveComponent preload",
+      scope: "elixir",
       prefix: ["plvs", "plc", "plcp"]
     }
   end
@@ -123,6 +140,7 @@ defmodule App.Snippets do
   def generate("live_component_render") do
     %Snippet{
       name: "LiveView: Phoenix.LiveComponent render",
+      scope: "elixir",
       prefix: ["plvs", "plc", "plcr"]
     }
   end
@@ -130,6 +148,7 @@ defmodule App.Snippets do
   def generate("live_component_update") do
     %Snippet{
       name: "LiveView: Phoenix.LiveComponent update",
+      scope: "elixir",
       prefix: ["plvs", "plc", "plcu"]
     }
   end
@@ -137,6 +156,7 @@ defmodule App.Snippets do
   def generate("live_view_handle_call") do
     %Snippet{
       name: "LiveView: handle_call",
+      scope: "elixir",
       prefix: ["plvs", "plv", "plvhi", "def", "def handle_call"]
     }
   end
@@ -144,6 +164,7 @@ defmodule App.Snippets do
   def generate("live_view_handle_cast") do
     %Snippet{
       name: "LiveView: handle_cast",
+      scope: "elixir",
       prefix: ["plvs", "plv", "plvhi", "def", "def handle_cast"]
     }
   end
@@ -151,6 +172,7 @@ defmodule App.Snippets do
   def generate("live_view_handle_event") do
     %Snippet{
       name: "LiveView: handle_event",
+      scope: "elixir",
       prefix: ["plvs", "plv", "plvhe", "def", "def handle_event"]
     }
   end
@@ -158,6 +180,7 @@ defmodule App.Snippets do
   def generate("live_view_handle_info") do
     %Snippet{
       name: "LiveView: handle_info",
+      scope: "elixir",
       prefix: ["plvs", "plv", "plvhi", "def", "def handle_info"]
     }
   end
@@ -165,6 +188,7 @@ defmodule App.Snippets do
   def generate("live_view_handle_params") do
     %Snippet{
       name: "LiveView: handle_params",
+      scope: "elixir",
       prefix: ["plvs", "plv", "plvhp", "def", "def handle_params"]
     }
   end
@@ -172,6 +196,7 @@ defmodule App.Snippets do
   def generate("live_view_impl") do
     %Snippet{
       name: "LiveView: @impl Phoenix.LiveView",
+      scope: "elixir",
       prefix: ["plvs", "plv", "@impl"]
     }
   end
@@ -179,6 +204,7 @@ defmodule App.Snippets do
   def generate("live_view_mount") do
     %Snippet{
       name: "LiveView: Phoenix.LiveView mount",
+      scope: "elixir",
       prefix: ["plvs", "plv", "plvm", "def mount"]
     }
   end
@@ -186,6 +212,7 @@ defmodule App.Snippets do
   def generate("live_view_new") do
     %Snippet{
       name: "LiveView: New LiveView module",
+      scope: "elixir",
       prefix: ["plvs", "plv", "plvnlvm", "defmodule"]
     }
   end
@@ -193,6 +220,7 @@ defmodule App.Snippets do
   def generate("live_view_render") do
     %Snippet{
       name: "LiveView: render implementation",
+      scope: "elixir",
       prefix: ["plvs", "plv", "plvr", "def render"]
     }
   end
@@ -200,6 +228,7 @@ defmodule App.Snippets do
   def generate("live_view_render_slot") do
     %Snippet{
       name: "LiveView: Render slot",
+      scope: "phoenix-heex",
       prefix: ["plvs", "plvrs"]
     }
   end
@@ -207,6 +236,7 @@ defmodule App.Snippets do
   def generate("live_view_socket_destructure") do
     %Snippet{
       name: "LiveView: socket destructure",
+      scope: "elixir",
       prefix: ["plvs", "plv", "plvsd", "socket"]
     }
   end
@@ -214,6 +244,7 @@ defmodule App.Snippets do
   def generate("live_view_terminate") do
     %Snippet{
       name: "LiveView: terminate",
+      scope: "elixir",
       prefix: ["plvs", "plv", "plvt", "def terminate"]
     }
   end
@@ -221,6 +252,7 @@ defmodule App.Snippets do
   def generate("phoenix_component_assign") do
     %Snippet{
       name: "Phoenix: Component assign/2",
+      scope: "elixir",
       prefix: ["plvs", "pc", "pca", "a", "assign"]
     }
   end
@@ -228,6 +260,7 @@ defmodule App.Snippets do
   def generate("phoenix_component_assign_new") do
     %Snippet{
       name: "Phoenix: Component assign_new/3",
+      scope: "elixir",
       prefix: ["plvs", "pc", "pca", "pcan", "a", "assign", "assign_new"]
     }
   end
@@ -235,6 +268,7 @@ defmodule App.Snippets do
   def generate("phoenix_component_assigns_to_attributes") do
     %Snippet{
       name: "Phoenix: Component assigns_to_attributes/2",
+      scope: "elixir",
       prefix: ["plvs", "pc", "pca", "pcat", "pcata", "a", "assigns", "assigns_to_attributes"]
     }
   end
@@ -242,6 +276,7 @@ defmodule App.Snippets do
   def generate("phoenix_component_changed") do
     %Snippet{
       name: "Phoenix: Component changed?/2",
+      scope: "elixir",
       prefix: ["plvs", "pc", "pcc", "c", "changed?"]
     }
   end
@@ -249,6 +284,7 @@ defmodule App.Snippets do
   def generate("phoenix_component_definition") do
     %Snippet{
       name: "Phoenix: Component definition",
+      scope: "elixir",
       prefix: ["plvs", "pc", "pcd"]
     }
   end
@@ -256,6 +292,7 @@ defmodule App.Snippets do
   def generate("phoenix_component_dynamic_tag") do
     %Snippet{
       name: "Phoenix: Phoenix.Component.dynamic_tag/1",
+      scope: "phoenix-heex",
       prefix: ["plvs", "pc", "pcc", "pcd", "pcdt", "<.", "<.dynamic_tag", "dynamic_tag"]
     }
   end
@@ -263,6 +300,7 @@ defmodule App.Snippets do
   def generate("phoenix_component_form") do
     %Snippet{
       name: "Phoenix: Phoenix.Component.form/1",
+      scope: "phoenix-heex",
       prefix: ["plvs", "pc", "pcf", "<.", "<.form", "form"]
     }
   end
@@ -270,6 +308,7 @@ defmodule App.Snippets do
   def generate("phoenix_component_inputs_for") do
     %Snippet{
       name: "Phoenix: Phoenix.Component.inputs_for/1",
+      scope: "phoenix-heex",
       prefix: ["plvs", "pc", "pci", "pcif", "<.", "<.inputs_for", "inputs_for"]
     }
   end
@@ -277,6 +316,7 @@ defmodule App.Snippets do
   def generate("phoenix_component_intersperse") do
     %Snippet{
       name: "Phoenix: Phoenix.Component.intersperse/1",
+      scope: "phoenix-heex",
       prefix: ["plvs", "pc", "pci", "<.", "<.intersperse", "intersperse"]
     }
   end
@@ -284,6 +324,7 @@ defmodule App.Snippets do
   def generate("phoenix_component_link") do
     %Snippet{
       name: "Phoenix: Phoenix.Component.link/1",
+      scope: "phoenix-heex",
       prefix: ["plvs", "pc", "pcl", "<.", "<.link", "link"]
     }
   end
@@ -291,6 +332,7 @@ defmodule App.Snippets do
   def generate("phoenix_component_live_file_input") do
     %Snippet{
       name: "Phoenix: Phoenix.Component.live_file_input/1",
+      scope: "phoenix-heex",
       prefix: [
         "plvs",
         "pc",
@@ -308,6 +350,7 @@ defmodule App.Snippets do
   def generate("phoenix_component_live_img_preview") do
     %Snippet{
       name: "Phoenix: Phoenix.Component.live_img_preview/1",
+      scope: "phoenix-heex",
       prefix: [
         "plvs",
         "pc",
@@ -325,6 +368,7 @@ defmodule App.Snippets do
   def generate("phoenix_component_live_title") do
     %Snippet{
       name: "Phoenix: Phoenix.Component.live_title/1",
+      scope: "phoenix-heex",
       prefix: [
         "plvs",
         "pc",
@@ -341,6 +385,7 @@ defmodule App.Snippets do
   def generate("phoenix_component_macros_attr") do
     %Snippet{
       name: "Phoenix: Component Macros attr/3",
+      scope: "elixir",
       prefix: ["plvs", "pc", "pcm", "pcma", "attr"]
     }
   end
@@ -348,6 +393,7 @@ defmodule App.Snippets do
   def generate("phoenix_component_macros_embed_templates") do
     %Snippet{
       name: "Phoenix: Component Macros embed_templates/2",
+      scope: "elixir",
       prefix: ["plvs", "pc", "pcm", "pcme", "pcmet", "embed_"]
     }
   end
@@ -355,6 +401,7 @@ defmodule App.Snippets do
   def generate("phoenix_component_macros_sigil_h") do
     %Snippet{
       name: "Phoenix: Component Macros sigil_H/2",
+      scope: "elixir",
       prefix: ["plvs", "pc", "pcm", "pcms", "pcmsh", "~H"]
     }
   end
@@ -362,6 +409,7 @@ defmodule App.Snippets do
   def generate("phoenix_component_macros_slot") do
     %Snippet{
       name: "Phoenix: Component Macros slot/2",
+      scope: "elixir",
       prefix: ["plvs", "pc", "pcm", "pcms", "slot"]
     }
   end
@@ -369,6 +417,7 @@ defmodule App.Snippets do
   def generate("phoenix_context_change") do
     %Snippet{
       name: "Phoenix: Context change",
+      scope: "elixir",
       prefix: ["plvs", "pctx", "pctxch"]
     }
   end
@@ -376,6 +425,7 @@ defmodule App.Snippets do
   def generate("phoenix_context_create") do
     %Snippet{
       name: "Phoenix: Context create",
+      scope: "elixir",
       prefix: ["plvs", "pctx", "pctxcr"]
     }
   end
@@ -383,6 +433,7 @@ defmodule App.Snippets do
   def generate("phoenix_context_delete") do
     %Snippet{
       name: "Phoenix: Context delete",
+      scope: "elixir",
       prefix: ["plvs", "pctx", "pctxd"]
     }
   end
@@ -390,6 +441,7 @@ defmodule App.Snippets do
   def generate("phoenix_context_get") do
     %Snippet{
       name: "Phoenix: Context get",
+      scope: "elixir",
       prefix: ["plvs", "pctx", "pctxg"]
     }
   end
@@ -397,6 +449,7 @@ defmodule App.Snippets do
   def generate("phoenix_context_list") do
     %Snippet{
       name: "Phoenix: Context list",
+      scope: "elixir",
       prefix: ["plvs", "pctx", "pctxl"]
     }
   end
@@ -404,6 +457,7 @@ defmodule App.Snippets do
   def generate("phoenix_context_update") do
     %Snippet{
       name: "Phoenix: Context update",
+      scope: "elixir",
       prefix: ["plvs", "pctx", "pctxu"]
     }
   end

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "phoenix-liveview-snippets",
   "displayName": "Phoenix LiveView snippets",
   "description": "A well documented set of snippets commonly used when writing LiveView code",
-  "version": "2.4.9",
+  "version": "2.4.10",
   "publisher": "phoenix-liveview-snippets",
   "engines": {
     "vscode": "^1.28.0"
@@ -15,7 +15,19 @@
     "snippets": [
       {
         "language": "elixir",
-        "path": "./snippets.json"
+        "path": "./elixir.code-snippets"
+      },
+      {
+        "language": "phoenix-heex",
+        "path": "./phoenix-heex.code-snippets"
+      },
+      {
+        "language": "html",
+        "path": "./phoenix-heex.code-snippets"
+      },
+      {
+        "language": "eex",
+        "path": "./phoenix-heex.code-snippets"
       }
     ]
   },


### PR DESCRIPTION
Separate out by language type in package.json instead of only using the scope field