### PR TITLE
Improve aliases for handle_call and handle_cast

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ teach yourself which snippet mnemonics you would prefer to use.
 | LiveView: Phoenix.LiveComponent update | plvs,plc,plcu | [Reference](#liveview-phoenix.livecomponent-update) |
 | LiveView: Phoenix.LiveView mount | plvs,plv,plvm,def mount | [Reference](#liveview-phoenix.liveview-mount) |
 | LiveView: Render slot | plvs,plvrs | [Reference](#liveview-render-slot) |
-| LiveView: handle_call | plvs,plv,plvhi,def,def handle_call | [Reference](#liveview-handle_call) |
-| LiveView: handle_cast | plvs,plv,plvhi,def,def handle_cast | [Reference](#liveview-handle_cast) |
+| LiveView: handle_call | plvs,plv,plvhc,plvhcl,def,def handle_call | [Reference](#liveview-handle_call) |
+| LiveView: handle_cast | plvs,plv,plvhc,plvhcl,def,def handle_cast | [Reference](#liveview-handle_cast) |
 | LiveView: handle_event | plvs,plv,plvhe,def,def handle_event | [Reference](#liveview-handle_event) |
 | LiveView: handle_info | plvs,plv,plvhi,def,def handle_info | [Reference](#liveview-handle_info) |
 | LiveView: handle_params | plvs,plv,plvhp,def,def handle_params | [Reference](#liveview-handle_params) |
@@ -306,7 +306,7 @@ end
 
 ### Prefixes
 
-<pre>plvs,plv,plvhi,def,def handle_call</pre>
+<pre>plvs,plv,plvhc,plvhcl,def,def handle_call</pre>
 
 ### Template
 <pre>
@@ -322,7 +322,7 @@ end
 
 ### Prefixes
 
-<pre>plvs,plv,plvhi,def,def handle_cast</pre>
+<pre>plvs,plv,plvhc,plvhcs,def,def handle_cast</pre>
 
 ### Template
 <pre>

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ teach yourself which snippet mnemonics you would prefer to use.
 | LiveView: Phoenix.LiveView mount | plvs,plv,plvm,def mount | [Reference](#liveview-phoenix.liveview-mount) |
 | LiveView: Render slot | plvs,plvrs | [Reference](#liveview-render-slot) |
 | LiveView: handle_call | plvs,plv,plvhc,plvhcl,def,def handle_call | [Reference](#liveview-handle_call) |
-| LiveView: handle_cast | plvs,plv,plvhc,plvhcl,def,def handle_cast | [Reference](#liveview-handle_cast) |
+| LiveView: handle_cast | plvs,plv,plvhc,plvhcs,def,def handle_cast | [Reference](#liveview-handle_cast) |
 | LiveView: handle_event | plvs,plv,plvhe,def,def handle_event | [Reference](#liveview-handle_event) |
 | LiveView: handle_info | plvs,plv,plvhi,def,def handle_info | [Reference](#liveview-handle_info) |
 | LiveView: handle_params | plvs,plv,plvhp,def,def handle_params | [Reference](#liveview-handle_params) |

--- a/lib/snippets.ex
+++ b/lib/snippets.ex
@@ -137,14 +137,14 @@ defmodule App.Snippets do
   def generate("live_view_handle_call") do
     %Snippet{
       name: "LiveView: handle_call",
-      prefix: ["plvs", "plv", "plvhi", "def", "def handle_call"]
+      prefix: ["plvs", "plv", "plvhc", "plvhcl", "def", "def handle_call"]
     }
   end
 
   def generate("live_view_handle_cast") do
     %Snippet{
       name: "LiveView: handle_cast",
-      prefix: ["plvs", "plv", "plvhi", "def", "def handle_cast"]
+      prefix: ["plvs", "plv", "plvhc", "plvhcs", "def", "def handle_cast"]
     }
   end
 


### PR DESCRIPTION
New aliases for `handle_call`: `plvhc` and `plvhcl`
New aliases for `handle_cast`: `plvhc` and `plvhcs`

`plvhi` is only for `handle_info`

I don't know if it is right to add `plvhcl` and `plvhcs` because it breaks the mnemonic rule. But without it we can not distinguish `handle_call` from `handle_cast`.

What do you think?