### PR TITLE
Fix tag name for Phoenix.Component.live_img_preview/1

### DIFF
--- a/lib/priv/snippets/phoenix_component_live_img_preview
+++ b/lib/priv/snippets/phoenix_component_live_img_preview
@@ -1,1 +1,1 @@
-<.live_image_preview entry={$1}$2/>$0
+<.live_img_preview entry={$1}$2/>$0


### PR DESCRIPTION
Rename `live_image_preview` to `live_img_preview`.

Example from documentation:

```heex
<%= for entry <- @uploads.avatar.entries do %>
  <.live_img_preview entry={entry} width="75" />
<% end %>
```

[Source](https://hexdocs.pm/phoenix_live_view/Phoenix.Component.html#live_img_preview/1)